### PR TITLE
Die if setreuid fails

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -94,9 +94,13 @@ meta_open(const char *name)
       metafile = stdout;
       return;
     }
-  setreuid(geteuid(), getuid());
+  if (setreuid(geteuid(), getuid()) == -1)
+    die("Failed to setreuid: %m");
+
   metafile = fopen(name, "w");
-  setreuid(geteuid(), getuid());
+  if (setreuid(geteuid(), getuid()) == -1)
+    die("Failed to setreuid: %m");
+
   if (!metafile)
     die("Failed to open metafile '%s'",name);
 }


### PR DESCRIPTION
Commit 4b8b1cb added a call to setreuid to drop root privileges before opening a certain file. According to [setreuid(2)](http://man7.org/linux/man-pages/man2/setreuid.2.html) calling setreuid may fail, which would actually lead to us opening that file as root. I added a check to make sure it succeeds, and if it doesn't, then call die.
