### PR TITLE
Support a soft memory limit for Memory Limit Exceeded errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@
 
 isolate: isolate.c
 	gcc -o isolate isolate.c -O2 -Wall -Wno-parentheses -Wno-unused-result -g -std=c99
+install:
+	cp isolate /usr/local/bin/isolate
+	chown root /usr/local/bin/isolate
+	chmod u+s /usr/local/bin/isolate
 
 isolate.1: isolate.1.txt
 	a2x -f manpage -D . $<


### PR DESCRIPTION
We required the ability for isolate to result in MLE, instead of either RTE or TLE. We implemented this by adding moreoless the same code as mooshak's safeexec program runs, but adapted to make the most of the functions already in place.

This adds a new parameter `--soft-mem` which is a memory limit which is not hard; there is more memory available, but it cannot be used. This way the program can actually attempt to allocate more memory, but it is detected and the program is terminated. Just make sure that `--mem` or `--cg-mem` is set to something higher if at all.

For this to be added, the `wait4` loop had to be changed, so that instead of letting `wait4` block execution, a do-while loop with regular sleep intervals handles that.

For getting the current memory usage, the data section of `/proc/<pid>/statm` is read. That is, the total memory usage of the process is considered to be `VmData + VmStk`.

Although this is a cap, it is enforced somewhat lightly, and in theory atleast, a program could allocate too much memory in less than 67ms and then immediately exit, therefore bypassing the check.
In a contest environment however, this will rarely be the case, and any overflow will be handled by a hard upper limit like `--cg-mem`.

