### PR TITLE
Made the check for timeout once every 0.01 sec

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -574,7 +574,7 @@ static void make_dir(char *path)
       if (sep)
 	*sep = 0;
 
-      if (!dir_exists(path) && mkdir(path, 0777) < 0)
+      if (mkdir(path, 0777) < 0 && (errno != EEXIST || !dir_exists(path)))
 	die("Cannot create directory %s: %m\n", path);
 
       if (!sep)

--- a/isolate.c
+++ b/isolate.c
@@ -45,6 +45,8 @@
 #define UNUSED __attribute__((unused))
 #define ARRAY_SIZE(a) (int)(sizeof(a)/sizeof(a[0]))
 
+#define MICROSEC_CHECK 10000
+
 static int timeout;			/* milliseconds */
 static int wall_timeout;
 static int extra_timeout;
@@ -984,7 +986,18 @@ signal_alarm(int unused UNUSED)
 {
   /* Time limit checks are synchronous, so we only schedule them there. */
   timer_tick = 1;
-  alarm(1);
+
+  /* http://www.gnu.org/software/libc/manual/html_node/Setting-an-Alarm.html
+   * for more about the API */
+
+  struct itimerval interval, before;
+
+  interval.it_interval.tv_usec = 0;
+  interval.it_interval.tv_sec = 0;
+  interval.it_value.tv_usec = (long int) MICROSEC_CHECK;
+  interval.it_value.tv_sec = 0;
+
+  setitimer (ITIMER_REAL, &new, &old);
 }
 
 static void
@@ -1101,7 +1114,8 @@ box_keeper(void)
     {
       sa.sa_handler = signal_alarm;
       sigaction(SIGALRM, &sa, NULL);
-      alarm(1);
+
+      signal_alarm(1);
     }
 
   for(;;)

--- a/isolate.c
+++ b/isolate.c
@@ -997,7 +997,7 @@ signal_alarm(int unused UNUSED)
   interval.it_value.tv_usec = (long int) MICROSEC_CHECK;
   interval.it_value.tv_sec = 0;
 
-  setitimer (ITIMER_REAL, &new, &old);
+  setitimer (ITIMER_REAL, &interval, &before);
 }
 
 static void


### PR DESCRIPTION
Changed signal_alarm function to set an interrupt after 0.01 sec (the exact time could easily be modified with the MICROSEC_CHECK macro). It uses settimer instead of alarm [More info here] (http://www.gnu.org/software/libc/manual/html_node/Setting-an-Alarm.html). This way the sandbox doesn't wait much (not more than 0.01 sec) after the process exceeds the time limt. Also 0.01 sec is not low enough to have a (noticeable) performance difference.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cms-dev/isolate/19)
<!-- Reviewable:end -->
