### PR TITLE
fix race condition in make_dir

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -572,7 +572,7 @@ static void make_dir(char *path)
       if (sep)
 	*sep = 0;
 
-      if (!dir_exists(path) && mkdir(path, 0777) < 0)
+      if (mkdir(path, 0777) < 0 && (errno != EEXIST || !dir_exists(path)))
 	die("Cannot create directory %s: %m\n", path);
 
       if (!sep)


### PR DESCRIPTION
If several instances of isolate are started simultaneously, there's a slight race condition when making directories (e.g. /tmp/box, if it does not already exist).

When mkdir fails we check if the path exists and is a directory, and in that case we don't emit an error.