### PR TITLE
Increase default num boxes

### DIFF
--- a/config.h
+++ b/config.h
@@ -7,7 +7,7 @@
 /* Range of UIDs and GIDs reserved for use by the sandboxes. */
 #define CONFIG_ISOLATE_FIRST_UID 60000
 #define CONFIG_ISOLATE_FIRST_GID 60000
-#define CONFIG_ISOLATE_NUM_BOXES 100
+#define CONFIG_ISOLATE_NUM_BOXES 1000
 
 /* Root of the cgroup hierarchy. */
 #define CONFIG_ISOLATE_CGROUP_ROOT "/sys/fs/cgroup"


### PR DESCRIPTION
This is necessary if you use CMS and want to start more than 10 workers on the same machine (otherwise, the workers will fail often). For example, on our private server (which has 32 cores) we sometimes use up to 16 workers.